### PR TITLE
utf-8_to_iso-8859-1

### DIFF
--- a/spylon_kernel/scala_interpreter.py
+++ b/spylon_kernel/scala_interpreter.py
@@ -383,7 +383,7 @@ class ScalaInterpreter(object):
             # and greater than a single system page.
             buff = fd.read(8192)
             if buff:
-                fn(buff.decode('utf-8'))
+                fn(buff.decode('iso-8859-1'))
 
     def interpret(self, code):
         """Interprets a block of Scala code.
@@ -412,7 +412,7 @@ class ScalaInterpreter(object):
 
         try:
             res = self.jimain.interpret(code, False)
-            pyres = self.jbyteout.toByteArray().decode("utf-8")
+            pyres = self.jbyteout.toByteArray().decode("iso-8859-1")
             # The scala interpreter returns a sentinel case class member here
             # which is typically matched via pattern matching.  Due to it
             # having a very long namespace, we just resort to simple string


### PR DESCRIPTION
This change fixes the crash of the interpreter with special characters in windows.

Working with Apache Spark in Jupyter Notebook in the windows operating system (in linux it does not happen), if the dataframe includes special characters, the interpreter is blocked indefinitely.

Analyzing the code I have been able to verify that for some reason the UTF-8 encoding is the one that caused the problem.